### PR TITLE
Update Community Member Profile Picture

### DIFF
--- a/web/src/components/Overlays/Info/CommunityCard.tsx
+++ b/web/src/components/Overlays/Info/CommunityCard.tsx
@@ -71,11 +71,21 @@ export const CommunityCard = ({ activeProjectData }) => {
             } else {
               fullName = ''
             }
-            const profileSrc =
-              d.profileUrl ||
-              `https://api.dicebear.com/7.x/initials/svg?seed=${fullName
-                .toLowerCase()
-                .replace(' ', '-')}.svg`
+
+            let profileSrc
+            if (d.profileUrl) {
+              if (d.profileUrl.startsWith('http')) {
+                profileSrc = d.profileUrl
+              } else {
+                profileSrc = process.env.AWS_STORAGE + '/' + d.profileUrl
+              }
+            } else {
+              profileSrc = `https://api.dicebear.com/7.x/initials/svg?seed=${fullName
+                .split(' ')
+                .map((name) => name[0])
+                .join('')
+                .slice(0, 2)}.svg`
+            }
             return (
               <div
                 style={{ marginTop: '32px' }}


### PR DESCRIPTION
There were two things going on here:
1. The API updated its URL, so we needed to provide a new one.
2. some of the `communityMember.profileUrl`s were actually pointing to AWS, not a URL.

I fixed the URL, updated the logic to account for the possibility of an AWS link, and fixed the initials logic to actually use first and last name, rather than the first two letters of their name.