### PR TITLE
Display Videos in Inlay

### DIFF
--- a/web/src/components/Map/Map.tsx
+++ b/web/src/components/Map/Map.tsx
@@ -230,7 +230,6 @@ export const Map = ({ urlProjectId }) => {
       map.on('mousemove', 'unclusteredTrees', (e) => {
         if (e.features.length > 0) {
           const treeInformation = getTreeInformation(e, activeProjectId)
-          console.log(treeInformation)
           setTreeData(treeInformation)
           if (hoveredTreeId !== null) {
             map.setFeatureState(


### PR DESCRIPTION
This allows videos to play properly on hover. It also fixes the issue of the photo width not matching the info width on some photos.