### PR TITLE
Close info card on first try

### DIFF
--- a/web/src/components/Map/Map.tsx
+++ b/web/src/components/Map/Map.tsx
@@ -45,7 +45,6 @@ export const Map = ({ initialOverlay, urlProjectId, mediaSize }) => {
   const activeProjectId = useSelector((state: State) => state.project.id)
   const setActiveProjectId = (id) => dispatch(setProjectId(id))
   const infoOverlay = useSelector((state: State) => state.overlays.info)
-  const [offInitialOverlay, setOffInitialOverlay] = useState<boolean>(false)
   const [map, setMap] = useState<mapboxgl.Map>()
   const [markers, setMarkers] = useState([])
   // TODO: Combine these two following useStates into one
@@ -72,13 +71,6 @@ export const Map = ({ initialOverlay, urlProjectId, mediaSize }) => {
       dispatch(setProjectId(urlProjectId))
     }
   }, [urlProjectId, activeProjectId])
-
-  useEffect(() => {
-    if (initialOverlay && !offInitialOverlay && !infoOverlay) {
-      dispatch(setInfoOverlay(initialOverlay))
-      setOffInitialOverlay(true)
-    }
-  }, [initialOverlay, infoOverlay, offInitialOverlay])
 
   // Initialize Map
   useEffect(() => {

--- a/web/src/components/Overlays/InfoOverlay.tsx
+++ b/web/src/components/Overlays/InfoOverlay.tsx
@@ -59,7 +59,7 @@ export const InfoOverlay = ({
       <ExitButton
         mediaSize={mediaSize}
         maximize={maximize}
-        onClick={() => dispatch(hideInfoOverlay())}
+        onClick={() => dispatch(setInfoOverlay(null))}
         style={null}
       />
       <InfoOverlayButton


### PR DESCRIPTION
This fixes a state issue that kept the project card from closing the first it's clicked on initial render. It also renames the full screen overlay for clarity.