### PR TITLE
Remove Fiat link

### DIFF
--- a/web/src/components/Overlays/Info/CommunityCard.tsx
+++ b/web/src/components/Overlays/Info/CommunityCard.tsx
@@ -39,9 +39,11 @@ export const CommunityCard = ({ activeProjectData, mediaSize, maximize }) => {
     ? totalFundsReceived.toFixed(2)
     : 0
 
-  const communityMembers = [...project.communityMembers].sort(
-    (a, b) => b.priority - a.priority
-  )
+  const communityMembers = [...project.communityMembers].sort((a, b) => {
+    if (a.priority === null) return 1
+    if (b.priority === null) return -1
+    return a.priority - b.priority
+  })
 
   const communityMembersCount = project.communityMembers.length
   const memberOrMembers = communityMembersCount == 1 ? 'member' : 'members'

--- a/web/src/components/Overlays/Info/PaymentsCard.tsx
+++ b/web/src/components/Overlays/Info/PaymentsCard.tsx
@@ -120,26 +120,34 @@ export const PaymentCard = ({ activeProjectData }) => {
                     <h3> {getDate(payment.timestamp)}</h3>
                     <p>
                       To:{' '}
-                      <a
-                        style={{
-                          margin: 0,
-                          color: '#808080',
-                          wordWrap: 'break-word',
-                          wordBreak: 'break-all',
-                          overflowWrap: 'break-word',
-                        }}
-                        href={
-                          payment.blockchain.toLowerCase() === 'celo'
-                            ? `https://explorer.celo.org/mainnet/tx/${payment.hash}`
-                            : `https://explorer.solana.com/tx/${payment.hash}`
-                        }
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {payment.firstName
-                          ? `${payment.firstName} ${payment.lastName}`
-                          : payment.to}
-                      </a>
+                      {payment.blockchain.startsWith('Fiat') ? (
+                        payment.firstName ? (
+                          `${payment.firstName} ${payment.lastName}`
+                        ) : (
+                          payment.to
+                        )
+                      ) : (
+                        <a
+                          style={{
+                            margin: 0,
+                            color: '#808080',
+                            wordWrap: 'break-word',
+                            wordBreak: 'break-all',
+                            overflowWrap: 'break-word',
+                          }}
+                          href={
+                            payment.blockchain.toLowerCase() === 'celo'
+                              ? `https://explorer.celo.org/mainnet/tx/${payment.hash}`
+                              : `https://explorer.solana.com/tx/${payment.hash}`
+                          }
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {payment.firstName
+                            ? `${payment.firstName} ${payment.lastName}`
+                            : payment.to}
+                        </a>
+                      )}
                     </p>
                     <p style={{ color: '#67962A' }}>${payment.amount}</p>
                     <InfoTag style={{ color: tagColors[payment.blockchain] }}>


### PR DESCRIPTION
This removes the link in the Payments tab on Fiat transactions. It also updates the sorting of Community Members in the Members tab to put them in the correct order.