### PR TITLE
shift search bar and icon

### DIFF
--- a/web/src/components/Map/components/SearchOverlay.tsx
+++ b/web/src/components/Map/components/SearchOverlay.tsx
@@ -188,7 +188,7 @@ const SearchInputBox = styled.input<{ theme }>`
   position: absolute;
   padding: 8px 12px;
   top: 6px;
-  left: 140px;
+  left: 152px;
   color: #ffffff;
   background-color: ${(props) => props.theme.colors.hinted};
   font-size: 0.875rem;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -302,7 +302,7 @@ margin-top: 4px;
   width: 20px;
   height: 20px;
   position: absolute;
-  left: 140px;
+  left: 160px;
   top: 17px;
   background-color: transparent;
   border: none;


### PR DESCRIPTION
This moves the search bar (and the search icon on mobile) over to the right a bit. This is to avoid collisions with the "Gainforest" text when browsing on Safari, where the text renders larger.