### PR TITLE
remove hexagons

### DIFF
--- a/web/src/components/Map/maputils.ts
+++ b/web/src/components/Map/maputils.ts
@@ -34,7 +34,7 @@ import {
 
 export const addAllSourcesAndLayers = (
   map: mapboxgl.Map,
-  hexagons,
+  // hexagons,
   hiveLocations,
   setMarkers
 ) => {
@@ -45,7 +45,7 @@ export const addAllSourcesAndLayers = (
   addAllSitesSourceAndLayer(map)
   addHighlightedSiteSourceAndLayer(map)
   // addNasaSourceAndLayer(map)
-  addHexagonsSourceAndLayers(map, hexagons)
+  // addHexagonsSourceAndLayers(map, hexagons)
   addHiveSourceAndLayers(map, hiveLocations, setMarkers)
   addTreesPlantedSourceAndLayers(map)
 }
@@ -69,29 +69,29 @@ export const toggleOrthomosaic = (map: mapboxgl.Map, visibility) => {
   }
 }
 
-export const addNasaSourceAndLayer = (map: mapboxgl.Map) => {
-  // const tilePath =
-  //   'wmts/epsg4326/best/' +
-  //   'MODIS_Terra_CorrectedReflectance_TrueColor/default/' +
-  //   '2018-06-01/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg'
+// export const addNasaSourceAndLayer = (map: mapboxgl.Map) => {
+//   // const tilePath =
+//   //   'wmts/epsg4326/best/' +
+//   //   'MODIS_Terra_CorrectedReflectance_TrueColor/default/' +
+//   //   '2018-06-01/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg'
 
-  const tilePath =
-    'https://gibs-c.earthdata.nasa.gov/wmts/epsg4326/best/wmts.cgi?TIME=2023-07-15T00:00:00Z&layer=VIIRS_NOAA20_CorrectedReflectance_TrueColor&style=default&tilematrixset=250m&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fjpeg&TileMatrix=1&TileCol=1&TileRow=0'
+//   const tilePath =
+//     'https://gibs-c.earthdata.nasa.gov/wmts/epsg4326/best/wmts.cgi?TIME=2023-07-15T00:00:00Z&layer=VIIRS_NOAA20_CorrectedReflectance_TrueColor&style=default&tilematrixset=250m&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fjpeg&TileMatrix=1&TileCol=1&TileRow=0'
 
-  console.log('im adding nasa ')
-  map.addSource('nasaSource', {
-    type: 'raster',
-    tiles: [
-      'https://gitc-b.earthdata.nasa.gov/wmts/epsg4326/best/wmts.cgi?TIME=2023-07-16T00:00:00Z&layer=VIIRS_SNPP_CorrectedReflectance_TrueColor&style=default&tilematrixset=250m&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fjpeg&TileMatrix={z}&TileCol={x}&TileRow={y}',
-    ],
-    tileSize: 256,
-  })
-  map.addLayer({
-    id: 'nasaLayer',
-    type: 'raster',
-    source: 'nasaSource',
-  })
-}
+//   console.log('im adding nasa ')
+//   map.addSource('nasaSource', {
+//     type: 'raster',
+//     tiles: [
+//       'https://gitc-b.earthdata.nasa.gov/wmts/epsg4326/best/wmts.cgi?TIME=2023-07-16T00:00:00Z&layer=VIIRS_SNPP_CorrectedReflectance_TrueColor&style=default&tilematrixset=250m&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fjpeg&TileMatrix={z}&TileCol={x}&TileRow={y}',
+//     ],
+//     tileSize: 256,
+//   })
+//   map.addLayer({
+//     id: 'nasaLayer',
+//     type: 'raster',
+//     source: 'nasaSource',
+//   })
+// }
 
 export const addClickableMarkers = (
   map: mapboxgl.Map,


### PR DESCRIPTION
This comments out or deletes all hexagon fetches. It also refactors a `useEffect` that occurs on project click. This refactor removes an iteration of searching through each asset, and also sets state as its able, rather than waiting for each fetch to finish before making any updates.