### PR TITLE
Add wallet address to members tab

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -20,6 +20,7 @@
     "@redwoodjs/web": "4.3.1",
     "prop-types": "15.8.1",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "react-tooltip": "^5.26.4"
   }
 }

--- a/web/src/components/Overlays/Info/CommunityCard.tsx
+++ b/web/src/components/Overlays/Info/CommunityCard.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react'
 
+import { Tooltip } from 'react-tooltip'
+
 import ThemedSkeleton from '../../Map/components/Skeleton'
 import { ToggleButton } from '../../Map/components/ToggleButton'
 
@@ -7,6 +9,13 @@ import { InfoBox } from './InfoBox'
 import { PaymentCard } from './PaymentsCard'
 export const CommunityCard = ({ activeProjectData, mediaSize, maximize }) => {
   const [toggle, setToggle] = useState<'Members' | 'Payments'>('Members')
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async (address) => {
+    await navigator.clipboard.writeText(address)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500) // Tooltip reset after 1.5s
+  }
 
   if (
     !activeProjectData ||
@@ -40,10 +49,11 @@ export const CommunityCard = ({ activeProjectData, mediaSize, maximize }) => {
     : 0
 
   const communityMembers = [...project.communityMembers].sort((a, b) => {
-    if (a.priority === null) return 1
-    if (b.priority === null) return -1
-    if (a.priority === b.priority) return b.fundsReceived - a.fundsReceived // sorting descending by fundsReceived
-    return a.priority - b.priority
+    if (a.priority === b.priority) {
+      return b.fundsReceived - a.fundsReceived
+    } else {
+      return a.priority - b.priority
+    }
   })
 
   const communityMembersCount = project.communityMembers.length
@@ -110,25 +120,52 @@ export const CommunityCard = ({ activeProjectData, mediaSize, maximize }) => {
                           <div>
                             <p style={{ margin: 0 }}>Celo: </p>
                             {d.Wallet?.CeloAccounts?.map((address) => (
-                              <p
+                              <button
                                 key={address}
-                                style={{ margin: 0, color: 'gray' }}
+                                style={{
+                                  background: 'transparent',
+                                  border: 'none',
+                                  cursor: 'pointer',
+                                  margin: 0,
+                                  color: 'gray',
+                                  fontSize: '16px',
+                                }}
+                                onClick={() => handleCopy(address)}
+                                data-tooltip-id="clipTip"
                               >
-                                {address}
-                              </p>
+                                {address.slice(0, 20)}...
+                              </button>
                             ))}
                           </div>
                         )}
+                        <Tooltip id="clipTip" delayShow={200} delayHide={500}>
+                          {copied
+                            ? 'Copied to clipboard!'
+                            : 'Click to copy to clipboard'}
+                        </Tooltip>
                         {d.Wallet?.SOLAccounts?.length > 0 && (
                           <div>
                             <p style={{ margin: 0 }}>Celo: </p>
                             {d.Wallet?.SOLAccounts?.map((address) => (
-                              <p
+                              <button
                                 key={address}
-                                style={{ margin: 0, color: 'gray' }}
+                                style={{
+                                  background: 'transparent',
+                                  border: 'none',
+                                  cursor: 'pointer',
+                                  margin: 0,
+                                  color: 'gray',
+                                  fontSize: '16px',
+                                }}
+                                onClick={() => handleCopy(address)}
+                                title={
+                                  copied
+                                    ? 'copied to clipboard!'
+                                    : 'click to copy to clipboard'
+                                }
                               >
                                 {address}
-                              </p>
+                              </button>
                             ))}
                           </div>
                         )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2747,6 +2747,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/core@npm:^1.0.0":
+  version: 1.6.2
+  resolution: "@floating-ui/core@npm:1.6.2"
+  dependencies:
+    "@floating-ui/utils": ^0.2.0
+  checksum: db2621dc682e7f043d6f118d087ae6a6bfdacf40b26ede561760dd53548c16e2e7c59031e013e37283801fa307b55e6de65bf3b316b96a054e4a6a7cb937c59e
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.6.1":
+  version: 1.6.5
+  resolution: "@floating-ui/dom@npm:1.6.5"
+  dependencies:
+    "@floating-ui/core": ^1.0.0
+    "@floating-ui/utils": ^0.2.0
+  checksum: ebdc14806f786e60df8e7cc2c30bf9cd4d75fe734f06d755588bbdef2f60d0a0f21dffb14abdc58dea96e5577e2e366feca6d66ba962018efd1bc91a3ece4526
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.2.0":
+  version: 0.2.2
+  resolution: "@floating-ui/utils@npm:0.2.2"
+  checksum: b2becdcafdf395af1641348da0031ff1eaad2bc60c22e14bd3abad4acfe2c8401e03097173d89a2f646a99b75819a78ef21ebb2572cab0042a56dd654b0065cd
+  languageName: node
+  linkType: hard
+
 "@gar/promisify@npm:^1.0.1, @gar/promisify@npm:^1.1.3":
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
@@ -10985,6 +11011,13 @@ __metadata:
     isobject: ^3.0.0
     static-extend: ^0.1.1
   checksum: d44f4afc7a3e48dba4c2d3fada5f781a1adeeff371b875c3b578bc33815c6c29d5d06483c2abfd43a32d35b104b27b67bfa39c2e8a422fa858068bd756cfbd42
+  languageName: node
+  linkType: hard
+
+"classnames@npm:^2.3.0":
+  version: 2.5.1
+  resolution: "classnames@npm:2.5.1"
+  checksum: afff4f77e62cea2d79c39962980bf316bacb0d7c49e13a21adaadb9221e1c6b9d3cdb829d8bb1b23c406f4e740507f37e1dcf506f7e3b7113d17c5bab787aa69
   languageName: node
   linkType: hard
 
@@ -22073,6 +22106,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-tooltip@npm:^5.26.4":
+  version: 5.26.4
+  resolution: "react-tooltip@npm:5.26.4"
+  dependencies:
+    "@floating-ui/dom": ^1.6.1
+    classnames: ^2.3.0
+  peerDependencies:
+    react: ">=16.14.0"
+    react-dom: ">=16.14.0"
+  checksum: f419baf6551c1cd812cc5d3dec76d027899f0ac99e20a50759ad26daa7bfabb3b9283345771f964e1dc973be7b16981f09b4c78f3ace3e1d8fe0389cecf8c199
+  languageName: node
+  linkType: hard
+
 "react@npm:17.0.2":
   version: 17.0.2
   resolution: "react@npm:17.0.2"
@@ -25995,6 +26041,7 @@ __metadata:
     prop-types: 15.8.1
     react: 17.0.2
     react-dom: 17.0.2
+    react-tooltip: ^5.26.4
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This adds wallet addresses to the members tab, and copies the address when clicked. 

It also sorts the communityMembers by fundsReceived if there are no priorities listed.