### PR TITLE
feat: add ability to view geojson from a url and hide UI if reqd

### DIFF
--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -19,10 +19,20 @@ const Routes = () => {
         <Route path="/methodology" page={MethodologyPage} name="methodology" />
         {/* <Set private unauthenticated="login"> */}
         {/* <Route path="/" page={LandingPage} name="landing" /> */}
-        <Route path="/{urlProjectId:String}/{initialOverlay:String?}" page={MapPage} name="map" />
-        <Route path="/{urlProjectId:String}" page={MapPage} name="map" />
-        <Route path="/map" page={MapPage} name="map" />
-        <Route path="/" page={MapPage} name="map" />
+        <Route path="/{projectId:String}/{overlay:String?}" page={MapPage} name="map" />
+        <Route path="/{projectId:String}" page={MapPage} name="map" />
+        <Route
+          path="/map"
+          page={MapPage}
+          name="map"
+          whitelistedSearchParams={['geojsonURL', 'showUI']}
+        />
+        <Route
+          path="/"
+          page={MapPage}
+          name="map"
+          whitelistedSearchParams={['geojsonURL', 'showUI']}
+        />
         <Route notfound page={NotFoundPage} />
       </Set>
     </Router>

--- a/web/src/components/Map/components/UrlUpdater.tsx
+++ b/web/src/components/Map/components/UrlUpdater.tsx
@@ -6,11 +6,11 @@ import { navigate } from '@redwoodjs/router'
 
 const UrlUpdater = () => {
   const infoOverlay = useSelector((state: State) => state.overlays.info)
-  const urlProjectId = useSelector((state: State) => state.project.id)
+  const projectId = useSelector((state: State) => state.project.id)
 
   useEffect(() => {
     if (infoOverlay != null) {
-      navigate(`/${urlProjectId}/${infoOverlay}`, { replace: true })
+      navigate(`/${projectId}/${infoOverlay}`, { replace: true })
     }
   }, [infoOverlay])
 

--- a/web/src/layouts/DefaultLayout/DefaultLayout.tsx
+++ b/web/src/layouts/DefaultLayout/DefaultLayout.tsx
@@ -1,3 +1,4 @@
+import { useLocation } from '@redwoodjs/router'
 import { useEffect, useState } from 'react'
 
 import { useAuth } from 'src/auth'
@@ -5,11 +6,14 @@ import Navbar from 'src/components/Navbar/Navbar'
 // import Sidebar from 'src/components/Sidebar/Sidebar'
 
 type DefaultLayoutProps = {
-  children?: React.ReactNode
+  children?: React.ReactNode,
 }
 
 const DefaultLayout = ({ children }: DefaultLayoutProps) => {
   const { isAuthenticated } = useAuth()
+
+  const { search } = useLocation()
+  const showNavbar = new URLSearchParams(search).get('showUI') !== 'false';
 
   const [mediaSize, setMediaSize] = useState(window.innerWidth)
   const [sidebarIsActive, setSidebarIsActive] = useState(true)
@@ -28,10 +32,10 @@ const DefaultLayout = ({ children }: DefaultLayoutProps) => {
 
   return (
     <div style={{ width: '100vw', height: '100vh', overflowX: 'hidden' }}>
-      <Navbar isAuthenticated={isAuthenticated} mediaSize={mediaSize} />
+      {showNavbar && <Navbar isAuthenticated={isAuthenticated} mediaSize={mediaSize} />}
       <div
         style={{
-          height: 'calc(100vh - 52px)',
+          height: `calc(100vh - ${showNavbar ? '52px' : '0px'})`,
           display: 'flex',
           width: '100%',
         }}

--- a/web/src/pages/MapPage/MapPage.tsx
+++ b/web/src/pages/MapPage/MapPage.tsx
@@ -1,10 +1,14 @@
 import { useEffect, useState } from 'react'
+import { useLocation } from '@redwoodjs/router'
 
 import 'react-loading-skeleton/dist/skeleton.css'
 import Map from 'src/components/Map/Map'
 
-const MapPage = ({ urlProjectId, initialOverlay }) => {
+const MapPage = ({ projectId, overlay }) => {
   const [mediaSize, setMediaSize] = useState(window.innerWidth)
+  const { search } = useLocation()
+  const geojsonURL = new URLSearchParams(search).get('geojsonURL')
+  const showUI = new URLSearchParams(search).get('showUI') !== 'false'
 
   useEffect(() => {
     const handleResize = () => {
@@ -16,9 +20,11 @@ const MapPage = ({ urlProjectId, initialOverlay }) => {
 
   return (
     <Map
-      urlProjectId={urlProjectId}
-      initialOverlay={initialOverlay}
+      projectId={projectId}
+      overlay={overlay}
       mediaSize={mediaSize}
+      geojsonURL={geojsonURL}
+      showUI={showUI}
     />
   )
 }


### PR DESCRIPTION
1. Refactor the variables `urlProjectId` to `projectId` and `initialOverlay` to `overlay`.
2. Expose a new query param, `geojsonURL` that accepts a geojson url and renders the polygon boundaries.
3. Expose a new optional query param, `showUI` that accepts a boolean value to render or not render the UI when displaying the geoJSON.
![image](https://github.com/user-attachments/assets/f31e77be-cada-41ae-a79e-15fccd32fb83)
