### PR TITLE
fix: improve accessibility and contrast ratios

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@reduxjs/toolkit": "^1.9.5",
     "@turf/bbox": "^6.5.0",
     "@turf/center": "^6.5.0",
+    "@turf/centroid": "^7.2.0",
     "@vercel/kv": "^1.0.1",
     "@what3words/react-components": "^4.1.2",
     "axios-hooks": "^5.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,6 @@
     "@redwoodjs/forms": "4.3.1",
     "@redwoodjs/router": "4.3.1",
     "@redwoodjs/web": "4.3.1",
-    "@turf/centroid": "^7.2.0",
     "aws-sdk": "^2.1657.0",
     "axios-hooks": "^5.0.2",
     "chart.js": "^4.4.3",

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
     "@redwoodjs/forms": "4.3.1",
     "@redwoodjs/router": "4.3.1",
     "@redwoodjs/web": "4.3.1",
+    "@turf/centroid": "^7.2.0",
     "aws-sdk": "^2.1657.0",
     "axios-hooks": "^5.0.2",
     "chart.js": "^4.4.3",

--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -25,13 +25,13 @@ const Routes = () => {
           path="/map"
           page={MapPage}
           name="map"
-          whitelistedSearchParams={['geojsonURL', 'showUI']}
+          whitelistedSearchParams={['shapefile', 'showUI']}
         />
         <Route
           path="/"
           page={MapPage}
           name="map"
-          whitelistedSearchParams={['geojsonURL', 'showUI']}
+          whitelistedSearchParams={['shapefile', 'showUI']}
         />
         <Route notfound page={NotFoundPage} />
       </Set>

--- a/web/src/components/Map/Map.tsx
+++ b/web/src/components/Map/Map.tsx
@@ -399,12 +399,59 @@ export const Map = ({ overlay, projectId, mediaSize, shapefile, showUI = true })
             // Add markers for each centroid
             centroids.features.forEach(point => {
               const marker = new mapboxgl.Marker({
-                color: '#FF00FF',
-                scale: 0.75
+                color: '#FFFFFF',  // White outer pin
+                scale: 0.75,
+                pitchAlignment: 'map',
+                rotationAlignment: 'map',
+                element: createCustomMarkerElement()  // Custom element for inner color
               })
               .setLngLat(point.geometry.coordinates)
               .addTo(map);
             });
+
+            // Helper function to create custom marker element
+            function createCustomMarkerElement() {
+              const markerRoot = document.createElement('div');
+              markerRoot.style.boxSizing = "border-box";
+
+
+              const markerLayout = document.createElement('div');
+              markerLayout.style.position = "relative";
+              markerLayout.style.boxSizing = "border-box";
+
+
+
+              const marker = document.createElement('div');
+              marker.style.boxSizing = "border-box";
+              marker.style.position = "absolute";
+              marker.style.bottom = "0";
+              marker.style.left = "50%";
+              marker.style.backgroundColor = '#FF00FF';  // Magenta inner circle
+              marker.style.width = '20px';
+              marker.style.height = '20px';
+              marker.style.borderRadius = '50%';
+              marker.style.borderBottomRightRadius = "10%";
+              marker.style.border = "2px solid #FFFFFF";
+              marker.style.transform = "translateX(-50%) rotateZ(45deg)";
+              // el.style.margin = '10px';
+
+              const markerDot = document.createElement('div');
+              markerDot.style.boxSizing = "border-box";
+              markerDot.style.position = "absolute";
+              markerDot.style.bottom = "7px";
+              markerDot.style.left = "50%";
+              markerDot.style.transform = "translateX(-50%)";
+              markerDot.style.borderRadius = "100%";
+              markerDot.style.backgroundColor = '#FFFFFF';  // Magenta inner circle
+              markerDot.style.width = '8px';
+              markerDot.style.height = '8px';
+
+
+              markerLayout.appendChild(marker);
+              markerLayout.appendChild(markerDot);
+              markerRoot.appendChild(markerLayout);
+              return markerRoot;
+            }
 
             // Fit bounds to the shapefile
             const bounds = bbox(data)

--- a/web/src/components/Map/Map.tsx
+++ b/web/src/components/Map/Map.tsx
@@ -362,17 +362,11 @@ export const Map = ({ overlay, projectId, mediaSize, shapefile, showUI = true })
             features: data.features.map(feature => centroid(feature))
           }
 
+          // Add polygon sources and layers first
           if (!map.getSource('customGeojson')) {
-            // Add polygon source
             map.addSource('customGeojson', {
               type: 'geojson',
               data: data
-            })
-
-            // Add centroid source
-            map.addSource('polygonCentroids', {
-              type: 'geojson',
-              data: centroids
             })
 
             // Add fill layer
@@ -402,21 +396,15 @@ export const Map = ({ overlay, projectId, mediaSize, shapefile, showUI = true })
               }
             })
 
-            // Add centroid markers
-            map.addLayer({
-              id: 'polygonCentroidMarkers',
-              type: 'circle',
-              source: 'polygonCentroids',
-              paint: {
-                'circle-radius': 10,
-                'circle-color': '#FF00FF',
-                'circle-stroke-width': 2,
-                'circle-stroke-color': '#FFFFFF'
-              },
-              layout: {
-                'visibility': 'visible'
-              }
-            })
+            // Add markers for each centroid
+            centroids.features.forEach(point => {
+              const marker = new mapboxgl.Marker({
+                color: '#FF00FF',
+                scale: 0.75
+              })
+              .setLngLat(point.geometry.coordinates)
+              .addTo(map);
+            });
 
             // Fit bounds to the shapefile
             const bounds = bbox(data)
@@ -436,10 +424,8 @@ export const Map = ({ overlay, projectId, mediaSize, shapefile, showUI = true })
     // Cleanup
     return () => {
       if (map && map.getSource('customGeojson')) {
-        if (map.getLayer('polygonCentroidMarkers')) map.removeLayer('polygonCentroidMarkers')
         if (map.getLayer('customGeojsonFill')) map.removeLayer('customGeojsonFill')
         if (map.getLayer('customGeojsonOutline')) map.removeLayer('customGeojsonOutline')
-        if (map.getSource('polygonCentroids')) map.removeSource('polygonCentroids')
         map.removeSource('customGeojson')
       }
     }

--- a/web/src/components/Map/Map.tsx
+++ b/web/src/components/Map/Map.tsx
@@ -65,7 +65,7 @@ ChartJS.register(
   Legend
 )
 
-export const Map = ({ overlay, projectId, mediaSize, geojsonURL, showUI = true }) => {
+export const Map = ({ overlay, projectId, mediaSize, shapefile, showUI = true }) => {
   const dispatch = useDispatch()
   const activeProjectId = useSelector((state: State) => state.project.id)
   const hoveredInformation = useSelector(
@@ -347,30 +347,29 @@ export const Map = ({ overlay, projectId, mediaSize, geojsonURL, showUI = true }
     }
   }, [map, activeProjectId, infoOverlay])
 
-  // Add new effect to fetch and handle geojsonURL data
+  // Add new effect to fetch and handle shapefile data
   useEffect(() => {
-    if (geojsonURL && !projectId && map) {
+    if (shapefile && !projectId && map) {
       const fetchGeojsonData = async () => {
         try {
-          const response = await fetch(geojsonURL)
+          const response = await fetch(shapefile)
           const data = await response.json()
           setGeojsonData(data)
 
-          // Add source and layer for the geojson data
           if (!map.getSource('customGeojson')) {
             map.addSource('customGeojson', {
               type: 'geojson',
               data: data
             })
 
-            // Add fill layer
+            // Add fill layer with low opacity
             map.addLayer({
               id: 'customGeojsonFill',
               type: 'fill',
               source: 'customGeojson',
               paint: {
-                'fill-color': '#088',
-                'fill-opacity': 0.3
+                'fill-color': '#FF00FF',
+                'fill-opacity': 0.15
               }
             })
 
@@ -379,13 +378,18 @@ export const Map = ({ overlay, projectId, mediaSize, geojsonURL, showUI = true }
               id: 'customGeojsonOutline',
               type: 'line',
               source: 'customGeojson',
+              layout: {
+                'line-cap': 'round',
+                'line-join': 'round',
+                'visibility': 'visible'
+              },
               paint: {
-                'line-color': '#088',
+                'line-color': '#FF00FF',
                 'line-width': 2
               }
             })
 
-            // Fit bounds to the geojson
+            // Fit bounds to the shapefile
             const bounds = bbox(data)
             map.fitBounds(bounds, {
               padding: { top: 40, bottom: 40, left: 40, right: 40 },
@@ -393,7 +397,7 @@ export const Map = ({ overlay, projectId, mediaSize, geojsonURL, showUI = true }
             })
           }
         } catch (error) {
-          console.error('Error fetching geojson:', error)
+          console.error('Error fetching shapefile:', error)
         }
       }
 
@@ -408,7 +412,7 @@ export const Map = ({ overlay, projectId, mediaSize, geojsonURL, showUI = true }
         map.removeSource('customGeojson')
       }
     }
-  }, [map, geojsonURL, projectId])
+  }, [map, shapefile, projectId])
 
   return (
     <>

--- a/web/src/pages/MapPage/MapPage.tsx
+++ b/web/src/pages/MapPage/MapPage.tsx
@@ -7,7 +7,7 @@ import Map from 'src/components/Map/Map'
 const MapPage = ({ projectId, overlay }) => {
   const [mediaSize, setMediaSize] = useState(window.innerWidth)
   const { search } = useLocation()
-  const geojsonURL = new URLSearchParams(search).get('geojsonURL')
+  const shapefile = new URLSearchParams(search).get('shapefile')
   const showUI = new URLSearchParams(search).get('showUI') !== 'false'
 
   useEffect(() => {
@@ -23,7 +23,7 @@ const MapPage = ({ projectId, overlay }) => {
       projectId={projectId}
       overlay={overlay}
       mediaSize={mediaSize}
-      geojsonURL={geojsonURL}
+      shapefile={shapefile}
       showUI={showUI}
     />
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -7425,10 +7425,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@turf/centroid@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "@turf/centroid@npm:7.2.0"
+  dependencies:
+    "@turf/helpers": ^7.2.0
+    "@turf/meta": ^7.2.0
+    "@types/geojson": ^7946.0.10
+    tslib: ^2.8.1
+  checksum: afdf72cbd140337638528055c509cc76c7839d3b0d6d0379d9bb1d9d04db4af840f1c17855dff6202df76072e87b2d9f02d1cd571f63a5ac704bd3a62c235afd
+  languageName: node
+  linkType: hard
+
 "@turf/helpers@npm:^6.5.0":
   version: 6.5.0
   resolution: "@turf/helpers@npm:6.5.0"
   checksum: 786cbe0c0027f85db286fb3a0b7be04bb29bd63ec07760a49735ef32e9c5b4a7c059a8f691fafa31c7e0e9be34c281e014dc24077438bae01a09b492a680fb6f
+  languageName: node
+  linkType: hard
+
+"@turf/helpers@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "@turf/helpers@npm:7.2.0"
+  dependencies:
+    "@types/geojson": ^7946.0.10
+    tslib: ^2.8.1
+  checksum: 4d6f57164cca00ec7a18e2d3c0200d0274e4ab2b6b3201c6a867b867d899f3f618a82ae242617d467efb04f32740cec150ae06a0e07ee39318397ebc34914687
   languageName: node
   linkType: hard
 
@@ -7438,6 +7460,16 @@ __metadata:
   dependencies:
     "@turf/helpers": ^6.5.0
   checksum: 9df6cb5af7af98a477ddcd744fb44e4e890fe8a67afa50bb24cad7d9c15af67362d24f1f8890d706a9c369b18285b0ba42430509add769ad868ac452703bb59b
+  languageName: node
+  linkType: hard
+
+"@turf/meta@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "@turf/meta@npm:7.2.0"
+  dependencies:
+    "@turf/helpers": ^7.2.0
+    "@types/geojson": ^7946.0.10
+  checksum: 707ed63ba64fe48769806bf2419f5c0cd2ebf821a6467aeffb784ba7ebd6a63ec98d4192b97915948529c00304ed46ddc83842a80714fb1f2018fd4e3c455498
   languageName: node
   linkType: hard
 
@@ -7689,6 +7721,13 @@ __metadata:
     "@types/qs": "*"
     "@types/serve-static": "*"
   checksum: 12e562c4571da50c7d239e117e688dc434db1bac8be55613294762f84fd77fbd0658ccd553c7d3ab02408f385bc93980992369dd30e2ecd2c68c358e6af8fabf
+  languageName: node
+  linkType: hard
+
+"@types/geojson@npm:^7946.0.10":
+  version: 7946.0.16
+  resolution: "@types/geojson@npm:7946.0.16"
+  checksum: 1ff24a288bd5860b766b073ead337d31d73bdc715e5b50a2cee5cb0af57a1ed02cc04ef295f5fa68dc40fe3e4f104dd31282b2b818a5ba3231bc1001ba084e3c
   languageName: node
   linkType: hard
 
@@ -25628,6 +25667,7 @@ __metadata:
     "@redwoodjs/core": 4.3.1
     "@turf/bbox": ^6.5.0
     "@turf/center": ^6.5.0
+    "@turf/centroid": ^7.2.0
     "@vercel/kv": ^1.0.1
     "@what3words/react-components": ^4.1.2
     axios-hooks: ^5.0.2
@@ -28056,6 +28096,13 @@ __metadata:
   version: 2.6.3
   resolution: "tslib@npm:2.6.3"
   checksum: 2598aef53d9dbe711af75522464b2104724d6467b26a60f2bdac8297d2b5f1f6b86a71f61717384aa8fd897240467aaa7bcc36a0700a0faf751293d1331db39a
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.8.1":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: 9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Changes
1. Improve the contrast ratios of the shape (outline and fill).
2. Use colors that are color-blind accessible.
3. Update the search param from "geojsonURL" to "shapefile" because the latter was prone to break due to case sensitivity.
![image](https://github.com/user-attachments/assets/9e7ee51f-60a4-47c5-993b-501ad6c428d8)
